### PR TITLE
Do not overwrite default linker flags so that LDFLAGS environment variable is considered

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   add_compile_options(-bigobj)
 else ()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
-  set(CMAKE_EXE_LINKER_FLAGS  "-rdynamic")
+  set(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} -rdynamic")
 endif ()
 
 #Thrift for clock


### PR DESCRIPTION
If a CMake build system of a project wants to specify additional linked flags, those should be appended to the [`CMAKE_EXE_LINKER_FLAGS`](https://cmake.org/cmake/help/latest/variable/CMAKE_EXE_LINKER_FLAGS.html) CMake variable. However, the original value of `CMAKE_EXE_LINKER_FLAGS` should not been overwritten, as this would lead to the [`LDFLAGS`  environment variable](https://cmake.org/cmake/help/latest/envvar/LDFLAGS.html) to be ignored, leading to linking errors in some environments that exploit this environment variable to specify the location of the libraries.

For more details see:
* https://github.com/osrf/gazebo/pull/2922
* https://github.com/robotology/robotology-superbuild/issues/681#issuecomment-817274209
